### PR TITLE
fix(#44): drop dead Universal Analytics gtag snippet from layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,13 +83,6 @@
     </section>
     <script type="text/javascript">var disqus_shortname = 'blog-zold-io';</script>
     <script id="dsq-count-scr" src="//blog-zold-io.disqus.com/count.js" async="async"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-1963507-54"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-1963507-54');
-    </script>
     <script type="text/javascript" >
       (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
       m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})


### PR DESCRIPTION
Issue #44 reported that `_layouts/default.html` lines 86 to 92 load `gtag.js` from Google Tag Manager and call `gtag('config', 'UA-1963507-54')`. The identifier `UA-1963507-54` is a Universal Analytics property, and Universal Analytics stopped processing new hits on 1 July 2023, so the snippet has been a dead tracker on every page of the published blog for almost three years.

The change removes the seven-line `<script>` block in one hunk. The Yandex Metrika tag immediately below it stays untouched, as does every other element of the layout. No replacement GA4 measurement ID is introduced because the choice between dropping analytics and adopting a GA4 property belongs to the maintainer; once a decision is made a follow-up pull request can wire in the new tag.

Built locally with `bundle exec ruby -rjekyll -e 'Jekyll::Site.new(Jekyll.configuration).process'` against Ruby 3.3 and Jekyll 4.4.1; the build finished without warnings and `grep -c "UA-1963507-54" _site/index.html` returned 0, confirming the dead tag is gone from the rendered output.

Closes #44
