### PR TITLE
docs(#50): point license badge at this repo's own LICENSE.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Blog of Zold
 
 [![jekyll](https://github.com/zold-io/blog.zold.io/actions/workflows/jekyll.yml/badge.svg)](https://github.com/zold-io/blog.zold.io/actions/workflows/jekyll.yml)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/yegor256/takes/blob/master/LICENSE.txt)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/zold-io/blog.zold.io/blob/master/LICENSE.txt)
 [![Hits-of-Code](https://hitsofcode.com/github/zold-io/blog.zold.io)](https://hitsofcode.com/view/github/zold-io/blog.zold.io)
 [![Availability at SixNines](https://www.sixnines.io/b/ee43)](https://www.sixnines.io/h/ee43)
 


### PR DESCRIPTION
Issue #50 reported that `README.md:4` ships the MIT-license badge with a target of `https://github.com/yegor256/takes/blob/master/LICENSE.txt`. That URL belongs to the unrelated `yegor256/takes` Java framework; the badge therefore promises one license but routes the reader to a different repository whose `LICENSE.txt` covers different software under different copyright. The other three badges on the same line (`jekyll`, `hitsofcode`, `sixnines`) already point at `zold-io/blog.zold.io`, so the `takes` link was a copy-paste leftover.

The change rewrites the badge target to `https://github.com/zold-io/blog.zold.io/blob/master/LICENSE.txt`, which is the `LICENSE.txt` the repository ships and which already declares `Copyright (c) 2018-2026 Zerocracy` under MIT. The Markdown badge image and label are unchanged; only the link target moves.

Verified by rendering the README locally and confirming the four badges now resolve to URLs under `zold-io/blog.zold.io` and `hitsofcode.com`/`sixnines.io` respectively. The diff is a single line and touches no code, no Liquid templates, and no workflows, so the project's CI matrix (`jekyll`, `markdown-lint`, `copyrights`, `reuse`, `typos`, `xcop`, `pdd`, `yamllint`, `actionlint`) is expected to pass unchanged.

Closes #50
