### PR TITLE
fix(#52): pin tacit CSS to versioned jsdelivr build, replacing dead cdn.rawgit.com link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <meta name="description" content="{{ page.description | split: ' ' | join: ' ' }}"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <link rel="shortcut icon" href="/images/logo-64.png"/>
-    <link rel="stylesheet" href="https://cdn.rawgit.com/yegor256/tacit/gh-pages/tacit-css.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/yegor256/tacit@v1.9.7/dist/tacit-css.min.css"/>
     <link rel="stylesheet" href="/css/main.css?20190417"/>
     <link rel="stylesheet" href="https://www.yegor256.com/css/icons.css"/>
     {% if page.date %}


### PR DESCRIPTION
Issue #52 reported that `_layouts/default.html:13` declares the page-wide Tacit stylesheet as `https://cdn.rawgit.com/yegor256/tacit/gh-pages/tacit-css.min.css`. The `cdn.rawgit.com` service was shut down by its operator in October 2019, so every request issued for that URL has been returning a 404 for six years. Because `_layouts/page.html` and `_layouts/post.html` both extend `default`, every blog post and page on `https://blog.zold.io` has been loading without the Tacit framework that the markup depends on for layout, typography, and form styling.

The change rewrites the single `<link>` in `_layouts/default.html` to fetch a versioned build from jsdelivr at `https://cdn.jsdelivr.net/gh/yegor256/tacit@v1.9.7/dist/tacit-css.min.css`. The release `v1.9.7` is the current latest tag of `yegor256/tacit` and the host is live and immutable per-version. The local `/css/main.css?20190417` and the icons stylesheet from `yegor256.com` are untouched.

Verified locally by building the site with `bundle exec jekyll build` against Ruby 3.3.6 and Jekyll 4.4.1; the build finished without warnings and `grep -rc "cdn.jsdelivr.net/gh/yegor256/tacit@v1.9.7" _site` returned a non-zero count for every generated page, confirming the new URL is what every page now emits and that the dead rawgit host is gone from the rendered output. A `curl -I` against the new URL returned `HTTP/2 200` with `x-jsd-version: 1.9.7`, so the asset is served.

Closes #52
