### PR TITLE
ci: pin xcop-action and pdd-action to immutable refs (closes #54)

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: volodya-lombrozo/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@69842b56627431c5f232f5ea2dc2fca82f409c54  # no release tags published; pinned to latest master

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@v1.3


### PR DESCRIPTION
`xcop.yml` and `pdd.yml` were the only workflows in `.github/workflows/` pinning a third-party action to the mutable `@master` ref; the other seven all pin to immutable tags. That allowed upstream changes to run in this repo's CI (under the workflow token) without any PR here.

This pins both to immutable refs, matching the rest of the bundle:

- `g4s8/xcop-action@master` -> `g4s8/xcop-action@v1.3` (latest release)
- `volodya-lombrozo/pdd-action@master` -> pinned to commit `69842b56627431c5f232f5ea2dc2fca82f409c54` (this action publishes no release tags, so a full commit SHA is used, which the issue notes is acceptable)

Closes #54.